### PR TITLE
feat(topology): track per-shard row counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ packages/
 # Install dependencies
 pnpm install
 
+# Login to wrangler (needed to parse SQL w/ AI)
+# Or set a CLOUDFLARE_API_TOKEN in the projects .env file
+wrangler login
+
 # Run locally
 pnpm dev
 

--- a/packages/big-daddy/llm-resources/conductor-crud.md
+++ b/packages/big-daddy/llm-resources/conductor-crud.md
@@ -20,12 +20,14 @@
 4. Execute per-shard INSERTs with remapped parameters
 5. Dispatch index maintenance events
 6. Invalidate cache
+7. **Bump per-shard row counts via `batchBumpTableShardRowCounts()`**
 
 **Key Functions:**
 - `groupInsertByShards()` - Groups rows by target shard, remaps placeholder indices
-- `extractInsertedRows()` - Builds row data for index maintenance
 
-**Important:** Multi-row INSERTs are split by shard key hash.
+**Important:** 
+- Multi-row INSERTs are split by shard key hash
+- Row counts use VALUES.length (not SQLite's rowsWritten which includes index writes)
 
 ---
 
@@ -50,6 +52,7 @@
 4. Execute on shards
 5. Dispatch index maintenance with old rows
 6. Invalidate cache
+7. **Decrement per-shard row counts via `batchBumpTableShardRowCounts()`**
 
 ---
 

--- a/packages/big-daddy/src/dashboard/database.tsx
+++ b/packages/big-daddy/src/dashboard/database.tsx
@@ -38,6 +38,7 @@ export const DashboardPage = ({
 			</h2>
 			<form method="post" action={`/dash/${databaseId}/sql`} class="space-y-3">
 				<textarea
+					id="sql-query"
 					name="query"
 					placeholder="Enter SQL query..."
 					class="w-full px-3 py-2 border-2 border-black text-sm font-mono focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black"
@@ -48,12 +49,13 @@ export const DashboardPage = ({
 				<div class="flex gap-3">
 					<button
 						type="submit"
-						class="flex-1 bg-black text-white font-medium py-2 hover:bg-white hover:text-black hover:border-2 hover:border-black border-2 border-black transition"
+						class="flex-1 bg-black text-white font-medium py-2 border-2 border-black hover:bg-white hover:text-black transition"
 					>
 						Execute
 					</button>
 					<button
-						type="reset"
+						type="button"
+						onclick="document.getElementById('sql-query').value = ''"
 						class="flex-1 bg-white text-black font-medium py-2 border-2 border-black hover:bg-black hover:text-white transition"
 					>
 						Clear

--- a/packages/big-daddy/src/engine/topology/resharding.ts
+++ b/packages/big-daddy/src/engine/topology/resharding.ts
@@ -82,8 +82,8 @@ export class ReshardingOperations {
 			const nodeId = nodes[nodeIndex]!.node_id;
 
 			this.storage.sql.exec(
-				`INSERT INTO table_shards (table_name, shard_id, node_id, status, created_at, updated_at)
-				 VALUES (?, ?, ?, 'pending', ?, ?)`,
+				`INSERT INTO table_shards (table_name, shard_id, node_id, status, row_count, created_at, updated_at)
+				 VALUES (?, ?, ?, 'pending', 0, ?, ?)`,
 				tableName,
 				shardId,
 				nodeId,
@@ -96,6 +96,7 @@ export class ReshardingOperations {
 				shard_id: shardId,
 				node_id: nodeId,
 				status: "pending",
+				row_count: 0,
 				created_at: now,
 				updated_at: now,
 			});

--- a/packages/big-daddy/src/engine/topology/types.ts
+++ b/packages/big-daddy/src/engine/topology/types.ts
@@ -33,7 +33,18 @@ export interface TableShard {
 	shard_id: number;
 	node_id: string;
 	status: "active" | "pending" | "to_be_deleted" | "failed";
+	row_count: number;
 	created_at: number;
+	updated_at: number;
+}
+
+/**
+ * Per-shard row count for a table
+ */
+export interface ShardRowCount {
+	table_name: string;
+	shard_id: number;
+	row_count: number;
 	updated_at: number;
 }
 


### PR DESCRIPTION
- Added `row_count` column to `table_shards` table
- INSERT and DELETE update row count
- Resharding sets the row count after data migration
- Schema migration to maintain compatibility just in case
- Updated LLM docs to be synced with the new code 